### PR TITLE
Client ID Dependency Injection fix.

### DIFF
--- a/Resources/config/services.xml
+++ b/Resources/config/services.xml
@@ -4,13 +4,13 @@
            xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
            xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
     <parameters>
-        <parameter key="happyr.stomp.broker_class">FuseSource\Stomp\Stomp</parameter>
+        <parameter key="happyr.stomp.broker_class">HappyR\StompBundle\Stomp\Stomp</parameter>
     </parameters>
 
     <services>
         <service id="happyr.stomp.broker" class="%happyr.stomp.broker_class%">
             <argument>%happyr.stomp.broker_uri%</argument>
-            <property name="clientId" type="string">%happyr.stomp.client_id%</property>
+            <argument>%happyr.stomp.client_id%</argument>
             <call method="connect"></call>
         </service>
     </services>

--- a/Stomp/Stomp.php
+++ b/Stomp/Stomp.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace HappyR\StompBundle\Stomp;
+
+class Stomp extends \FuseSource\Stomp\Stomp {
+
+    public function __construct($brokerUri, $clientId) {
+        parent::__construct($brokerUri);
+        $this->clientId = $clientId;
+    }
+
+}


### PR DESCRIPTION
Symfony calls the `connect` method before property injection. As I investigated the issue, I found no way to prioritize the injections so a new way was needed.
Because there is no setter for `clientId`, It has to be injected through constructor (or a setter).
